### PR TITLE
Add HTML Capture and Rendering

### DIFF
--- a/app/controllers/snap_shots_controller.rb
+++ b/app/controllers/snap_shots_controller.rb
@@ -1,5 +1,5 @@
 class SnapShotsController < ApplicationController
-  before_action :set_snap_shot, only: %i[ show ]
+  before_action :set_snap_shot, only: %i[ show show_html ]
   before_action :authenticate_user!
 
   def show
@@ -9,6 +9,17 @@ class SnapShotsController < ApplicationController
 
   def create
     SnapShotJob.perform_later(Domain.find(params[:id]))
+  end
+
+  def show_html
+    html_blob = @snap_shot.html_file
+
+    # Stream the file with explicit inline disposition and content type
+    response.headers['Content-Disposition'] = "inline; filename=\"#{html_blob.filename}\""
+    response.headers['Content-Type'] = html_blob.content_type
+
+    # Stream the file body
+    send_data html_blob.download, disposition: 'inline', filename: html_blob.filename.to_s
   end
 
   private

--- a/app/models/snap_shot.rb
+++ b/app/models/snap_shot.rb
@@ -9,6 +9,8 @@ class SnapShot < ApplicationRecord
     attachable.variant :thumb, crop: [0, 0, 1000, 1000], preprocessed: true
   end
 
+  has_one_attached :html_file
+
   scope :for_domain_desktop, ->(domain) { where(domain_id: domain.id, format: 'desktop') }
   scope :for_domain_mobile, ->(domain) { where(domain_id: domain.id, format: 'mobile') }
 end

--- a/app/views/snap_shots/show.html.erb
+++ b/app/views/snap_shots/show.html.erb
@@ -13,10 +13,16 @@
         </div>
       </div>
 
-      <div class="btn-toolbar mb-2 mb-md-0">
-        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">
-          Display Full Screen
-        </button>
+      <div class="d-flex">
+        <div class="btn-toolbar mb-2 mb-md-0 ms-2 me-2">
+          <%= link_to "View HTML", snap_shot_html_path(@snap_shot), target: "_blank", rel: "noopener", class: "btn btn-primary" %>
+        </div>
+        
+        <div class="btn-toolbar mb-2 mb-md-0">
+          <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">
+            Display Full Screen
+          </button>
+        </div>
       </div>
 
     </div>

--- a/app/views/snap_shots/show.html.erb
+++ b/app/views/snap_shots/show.html.erb
@@ -14,10 +14,11 @@
       </div>
 
       <div class="d-flex">
-        <div class="btn-toolbar mb-2 mb-md-0 ms-2 me-2">
-          <%= link_to "View HTML", snap_shot_html_path(@snap_shot), target: "_blank", rel: "noopener", class: "btn btn-primary" %>
-        </div>
-        
+        <% if @snap_shot.html_file.attached? %>
+          <div class="btn-toolbar mb-2 mb-md-0 ms-2 me-2">
+            <%= link_to "View HTML", snap_shot_html_path(@snap_shot), target: "_blank", rel: "noopener", class: "btn btn-primary" %>
+          </div>
+        <% end %>
         <div class="btn-toolbar mb-2 mb-md-0">
           <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">
             Display Full Screen

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   get "snap_shots/:id", to: "snap_shots#show", as: :snap_shots
   post "snap_shots/create/:id", to: "snap_shots#create", as: :take_snap_shot
+  get "snap_shots/:id/html", to: "snap_shots#show_html", as: :snap_shot_html
 
   post "domain_schedules/set_activation/:id", to: "domain_schedules#set_activation", as: :set_domain_schedule_activation
 


### PR DESCRIPTION
snap shot service now saves and attaches an html file to a snap shot. users can load a page with this file from the snap shot show page